### PR TITLE
perf: reuse Highlighter QueryCache across renders

### DIFF
--- a/src/highlight.zig
+++ b/src/highlight.zig
@@ -23,6 +23,10 @@ pub const Highlighter = struct {
     };
   }
 
+  pub fn deinit(self: *Highlighter) void {
+    self.query_cache.deinit();
+  }
+
   pub fn highlight(self: *Highlighter, content: Bytes, lang: Bytes, spans: *std.ArrayList(Span)) !bool {
     const parser = Syntax.create_file_type_static(self.allocator, lang, self.query_cache) catch return false;
     

--- a/src/main.zig
+++ b/src/main.zig
@@ -262,6 +262,7 @@ fn watchNormal(_: std.mem.Allocator, path: []const u8, ctx: cli.Ctx, timing: boo
   var last_mtime: i128 = 0;
   var last_size: u64 = 0;
   var highlighter = try ink.Highlighter.init(std.heap.page_allocator);
+  defer highlighter.deinit();
 
   while (true) {
     const stat = std.fs.cwd().statFile(path) catch {

--- a/src/main.zig
+++ b/src/main.zig
@@ -140,6 +140,7 @@ fn handleEditor(tui: *ink.tui.Tui, path: []const u8, ctx: cli.Ctx) void {
 
 fn viewLoop(tui: *ink.tui.Tui, opts: TuiOptions, ctx: cli.Ctx) !bool {
   var highlighter = try ink.Highlighter.init(std.heap.page_allocator);
+  defer highlighter.deinit();
   while (true) switch (try launchTui(tui, opts, &highlighter)) {
     .quit => return true,
     .back_to_picker => return false,
@@ -224,7 +225,8 @@ fn renderNormal(_: std.mem.Allocator, path: []const u8, ctx: cli.Ctx, timing: bo
 
   const base_dir = std.fs.path.dirname(path) orelse ".";
   var highlighter = try ink.Highlighter.init(std.heap.page_allocator);
-  
+  defer highlighter.deinit();
+
   try ink.render(w, root, .{ 
     .highlighter = &highlighter, .margin = mem.margin, 
     .line_wrap_percent = mem.line_wrap_percent, .base_path = base_dir 

--- a/src/main.zig
+++ b/src/main.zig
@@ -139,14 +139,15 @@ fn handleEditor(tui: *ink.tui.Tui, path: []const u8, ctx: cli.Ctx) void {
 }
 
 fn viewLoop(tui: *ink.tui.Tui, opts: TuiOptions, ctx: cli.Ctx) !bool {
-  while (true) switch (try launchTui(tui, opts)) {
+  var highlighter = try ink.Highlighter.init(std.heap.page_allocator);
+  while (true) switch (try launchTui(tui, opts, &highlighter)) {
     .quit => return true,
     .back_to_picker => return false,
     .edit => handleEditor(tui, opts.path, ctx),
   };
 }
 
-fn launchTui(tui: *ink.tui.Tui, opts: TuiOptions) !LaunchResult {
+fn launchTui(tui: *ink.tui.Tui, opts: TuiOptions, highlighter: *ink.Highlighter) !LaunchResult {
   const alloc = tui.alloc;
   const mem = Memory.load(alloc);
 
@@ -161,9 +162,8 @@ fn launchTui(tui: *ink.tui.Tui, opts: TuiOptions) !LaunchResult {
   var aw: std.Io.Writer.Allocating = .init(std.heap.page_allocator);
   defer aw.deinit();
 
-  var highlighter = try ink.Highlighter.init(std.heap.page_allocator);
   try ink.render(&aw.writer, root, .{
-    .highlighter = &highlighter,
+    .highlighter = highlighter,
     .show_urls = mem.show_urls,
     .tui = true,
   });
@@ -173,7 +173,7 @@ fn launchTui(tui: *ink.tui.Tui, opts: TuiOptions) !LaunchResult {
   return switch (try ink.tui.run(tui, rendered, opts.path, .{
     .watching = opts.watching,
     .has_picker = opts.has_picker,
-  })) {
+  }, highlighter)) {
     .quit => .quit,
     .back_to_picker => .back_to_picker,
     .edit => .edit,
@@ -259,6 +259,7 @@ fn watchNormal(_: std.mem.Allocator, path: []const u8, ctx: cli.Ctx, timing: boo
 
   var last_mtime: i128 = 0;
   var last_size: u64 = 0;
+  var highlighter = try ink.Highlighter.init(std.heap.page_allocator);
 
   while (true) {
     const stat = std.fs.cwd().statFile(path) catch {
@@ -286,7 +287,6 @@ fn watchNormal(_: std.mem.Allocator, path: []const u8, ctx: cli.Ctx, timing: boo
       try w.writeAll("\x1b[H\x1b[2J\x1b[3J");
 
       const base_dir = std.fs.path.dirname(path) orelse ".";
-      var highlighter = try ink.Highlighter.init(std.heap.page_allocator);
       
       try ink.render(w, root, .{ 
         .highlighter = &highlighter, .margin = mem.margin, 

--- a/src/view.zig
+++ b/src/view.zig
@@ -25,7 +25,7 @@ const Memory = memory.Memory;
 
 pub const RunResult = enum { quit, back_to_picker, edit };
 
-fn reloadContent(alloc: std.mem.Allocator, path: Bytes, show_urls: bool) !struct { rendered: Bytes, arena: *node.Arena } {
+fn reloadContent(alloc: std.mem.Allocator, path: Bytes, show_urls: bool, highlighter: *hl.Highlighter) !struct { rendered: Bytes, arena: *node.Arena } {
   var arena = try alloc.create(node.Arena);
   arena.* = node.Arena.init(std.heap.page_allocator);
 
@@ -35,11 +35,9 @@ fn reloadContent(alloc: std.mem.Allocator, path: Bytes, show_urls: bool) !struct
   const markdown = try file.readToEndAlloc(arena.allocator(), std.math.maxInt(usize));
   const root = try parser.parse(arena, markdown);
 
-  var highlighter = try hl.Highlighter.init(std.heap.page_allocator);
-
   var aw: std.Io.Writer.Allocating = .init(alloc);
   try output.render(&aw.writer, root, .{
-    .highlighter = &highlighter,
+    .highlighter = highlighter,
     .show_urls = show_urls,
     .tui = true,
   });
@@ -51,8 +49,8 @@ fn reloadContent(alloc: std.mem.Allocator, path: Bytes, show_urls: bool) !struct
   return .{ .rendered = rendered, .arena = arena };
 }
 
-fn refreshContent(alloc: std.mem.Allocator, filename: Bytes, v: *Viewer, prev_rendered: *?[]const u8, prev_arena: *?*node.Arena, prev_parsed: *types.ParseResult) void {
-  const result = reloadContent(alloc, filename, v.show_urls) catch return;
+fn refreshContent(alloc: std.mem.Allocator, filename: Bytes, v: *Viewer, prev_rendered: *?[]const u8, prev_arena: *?*node.Arena, prev_parsed: *types.ParseResult, highlighter: *hl.Highlighter) void {
+  const result = reloadContent(alloc, filename, v.show_urls, highlighter) catch return;
   const new_parsed = parse.parseAnsiLines(alloc, result.rendered) catch {
     alloc.free(result.rendered);
     result.arena.deinit();
@@ -148,7 +146,7 @@ pub const Tui = struct {
   }
 };
 
-pub fn run(tui: *Tui, rendered: Bytes, filename: Bytes, opts: Options) !RunResult {
+pub fn run(tui: *Tui, rendered: Bytes, filename: Bytes, opts: Options, highlighter: *hl.Highlighter) !RunResult {
   const alloc = tui.alloc;
   var parsed = try parse.parseAnsiLines(alloc, rendered);
   const mem = Memory.load(alloc);
@@ -202,7 +200,7 @@ pub fn run(tui: *Tui, rendered: Bytes, filename: Bytes, opts: Options) !RunResul
     const event = tui.loop.nextEvent();
     switch (event) {
       .file_changed => {
-        refreshContent(alloc, filename, &v, &prev_rendered, &prev_arena, &parsed);
+        refreshContent(alloc, filename, &v, &prev_rendered, &prev_arena, &parsed, highlighter);
       },
       .key_press => |key| {
         if (v.yank_active) {
@@ -218,9 +216,9 @@ pub fn run(tui: *Tui, rendered: Bytes, filename: Bytes, opts: Options) !RunResul
           if (action == .back_to_picker) return .back_to_picker;
           if (action == .edit) return .edit;
           if (action == .reload) {
-            refreshContent(alloc, filename, &v, &prev_rendered, &prev_arena, &parsed);
+            refreshContent(alloc, filename, &v, &prev_rendered, &prev_arena, &parsed, highlighter);
           }
-          if (action == .toggle_urls) refreshContent(alloc, filename, &v, &prev_rendered, &prev_arena, &parsed);
+          if (action == .toggle_urls) refreshContent(alloc, filename, &v, &prev_rendered, &prev_arena, &parsed, highlighter);
           if (action == .outline) {
             if (outline.run(tui, v.headings) catch null) |result| {
               const vrow = v.wrap.logicalToVisual(result.line_idx);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized syntax highlighter management to reduce repeated initialization and improve rendering consistency.
  * Added explicit cleanup for the highlighter to reduce resource usage and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->